### PR TITLE
Version 0.2.10.229 update to handle '#' in filenames when reading sample sheet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MAVEQC
 Title: A R package for MAVE QC
-Version: 0.2.9.229
+Version: 0.2.10.229
 Authors@R:
     person("Fei", "Sang", , "fei.sang@sanger.ac.uk", 
             role = c("aut", "cre"),

--- a/R/ingest.R
+++ b/R/ingest.R
@@ -110,7 +110,7 @@ import_sge_files <- function(dir_path = NULL,
     }
 
     # read sample sheet and check format
-    qc_samplesheet <<- read.table(paste0(dir_path, "/", sample_sheet), sep = "\t", comment.char = "#", header = TRUE, fill = TRUE)
+    qc_samplesheet <<- read.table(paste0(dir_path, "/", sample_sheet), sep = "\t", comment.char = "", header = TRUE, fill = TRUE)
     require_cols <- c("sample_name",
                       "replicate",
                       "condition",

--- a/R/qc_reports.R
+++ b/R/qc_reports.R
@@ -243,7 +243,7 @@ create_qc_reports <- function(samplesheet = NULL,
         cat("### 2.1. Sample Sheet", "\n", sep = "")
         cat("\n", sep = "")
         cat("```{r, echo = FALSE}", "\n", sep = "")
-        cat("df <- as.data.frame(read.table(\"", samplesheet, "\", header = TRUE, sep = \"\\t\", check.names = FALSE))", "\n", sep = "")
+        cat("df <- as.data.frame(read.table(\"", samplesheet, "\", header = TRUE, sep = \"\\t\", check.names = FALSE, comment.char = \"\"))", "\n", sep = "")
         cat("min_row <- ifelse(nrow(df) > 10, 10, nrow(df))", "\n", sep = "")
         cat("reactable(df, highlight = TRUE, bordered = TRUE, striped = TRUE, compact = TRUE, wrap = TRUE,", "\n", sep = "")
         cat("          filterable = TRUE, minRows = min_row, defaultColDef = colDef(minWidth = 150, align = \"left\"),", "\n", sep = "")

--- a/tests/testthat/test_ingest.R
+++ b/tests/testthat/test_ingest.R
@@ -1,7 +1,8 @@
 library(testthat)
+library(withr)
 
 test_that("import_sge_files correctly reads '#' in manifest fields", {
-    tmp_dir <- tempdir()
+    withr::local_tempdir()
 
     # Generate files that the samplesheet points to
     writeLines(
@@ -9,7 +10,7 @@ test_that("import_sge_files correctly reads '#' in manifest fields", {
             "oligo_name,ref_seq,pam_seq",
             "oligo1,ATGC,ATGC"
         ),
-        file.path(tmp_dir, "#meta.csv")
+        file.path(tempdir(), "#meta.csv")
     )
 
     writeLines(
@@ -20,7 +21,7 @@ test_that("import_sge_files correctly reads '#' in manifest fields", {
             "1\ta\tATCG\t4\t5\t1\ts1",
             "2\tb\tATGC\t4\t10\t1\ts1"
         ),
-        file.path(tmp_dir, "lib#_#counts.tsv")
+        file.path(tempdir(), "lib#_#counts.tsv")
       )
 
     writeLines(
@@ -31,7 +32,7 @@ test_that("import_sge_files correctly reads '#' in manifest fields", {
             "ATCG\t4\t5",
             "ATGC\t4\t10"
         ),
-        file.path(tmp_dir, "query_counts.tsv")
+        file.path(tempdir(), "query_counts.tsv")
       )
 
     writeLines(
@@ -39,7 +40,7 @@ test_that("import_sge_files correctly reads '#' in manifest fields", {
             "unique_oligo_name\tGene\tSYMBOL\tTargeton_ID\tsgRNA_id\tFeature\tEXON\tSeq",
             "ENST01OLG1\tgene1\tg1\tAAAA\t001\tENST01\t-\tATCG"
         ),
-        file.path(tmp_dir, "meta_consequences###.tsv")
+        file.path(tempdir(), "meta_consequences###.tsv")
     )
 
     # Generate samplesheet
@@ -48,11 +49,11 @@ test_that("import_sge_files correctly reads '#' in manifest fields", {
             "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
             "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_#counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences###.tsv\tR1\tDay0\tDay0\tATCG\tATCG"
         ),
-        file.path(tmp_dir, "samplesheet.tsv")
+        file.path(tempdir(), "samplesheet.tsv")
     )
 
     # Run function and get samplesheet df object
-    sge_objects <- import_sge_files(dir_path = tmp_dir,
+    sge_objects <- import_sge_files(dir_path = tempdir(),
                                     sample_sheet = "samplesheet.tsv")
 
     samplesheet_df <- get("qc_samplesheet", envir = .GlobalEnv)

--- a/tests/testthat/test_ingest.R
+++ b/tests/testthat/test_ingest.R
@@ -1,0 +1,57 @@
+library(testthat)
+
+test_that("import_sge_files correctly reads '#' in manifest fields", {
+
+  # Generate files
+  tmp_dir <- tempdir()
+
+  writeLines(
+    c(
+      "oligo_name,species,assembly,gene_id,transcript_id,src_type,ref_chr,ref_strand,ref_start,ref_end,revc,ref_seq,pam_seq,vcf_alias,vcf_var_id,mut_position,ref,new,ref_aa,alt_aa,mut_type,mutator,oligo_length,mseq,mseq_no_adapt,pam_mut_annot,pam_mut_sgrna_id,mave_nt,mave_nt_ref,vcf_var_in_const",
+      "oligo1,homo sapiens,GRCh38,GENE1,AA1,ref,chr1,+,100,200,0,ATGC,ATGC,alias1,var1,120,A,T,K,N,1del,mut1,50,ATGC,ATGC,annot1,guide1,A,A,del1"
+      ),
+    file.path(tmp_dir, "#meta.csv")
+  )
+
+  writeLines(
+  c(
+    "##Command: pyquest",
+    "##Version: 1.1.0",
+    "#ID\tNAME\tSEQUENCE\tLENGTH\tCOUNT\tUNIQUE\tSAMPLE",
+    "1\ta\tATCG\t4\t5\t1\ts1",
+    "2\tb\tATGC\t4\t10\t1\ts1"
+    ),
+   file.path(tmp_dir, "lib#_counts.tsv")
+  )
+
+  writeLines(
+    c(
+      "##Command: pyquest",
+      "##Version: 1.1.0",
+      "#SEQUENCE\tLENGTH\tCOUNT",
+      "ATCG\t4\t5",
+      "ATGC\t4\t10"
+      ),
+     file.path(tmp_dir, "query_counts.tsv")
+    )
+
+  writeLines(
+    c(
+        "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
+        "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences.tsv\tR1\tDay0\tDay0\tATCG\tATCG"
+    ),
+    file.path(tmp_dir, "samplesheet.tsv")
+  )
+
+  # Run function
+  sge_objects <- import_sge_files(dir_path = tmp_dir, sample_sheet = "samplesheet.tsv")
+
+  # Check filenames are preserved
+  df <- get("qc_samplesheet", envir = .GlobalEnv)
+
+  expect_equal(df$fastq_1[1], "sample1#.fastq.gz")
+  expect_equal(df$valiant_meta[1], "#meta.csv")
+  expect_equal(df$library_dependent_count[1], "lib#_counts.tsv")
+  expect_equal(df$library_independent_count[1], "query_counts.tsv")
+  expect_equal(df$vep_anno[1], "meta_consequences.tsv")
+})

--- a/tests/testthat/test_ingest.R
+++ b/tests/testthat/test_ingest.R
@@ -1,57 +1,66 @@
 library(testthat)
 
 test_that("import_sge_files correctly reads '#' in manifest fields", {
+    tmp_dir <- tempdir()
 
-  # Generate files
-  tmp_dir <- tempdir()
-
-  writeLines(
-    c(
-      "oligo_name,species,assembly,gene_id,transcript_id,src_type,ref_chr,ref_strand,ref_start,ref_end,revc,ref_seq,pam_seq,vcf_alias,vcf_var_id,mut_position,ref,new,ref_aa,alt_aa,mut_type,mutator,oligo_length,mseq,mseq_no_adapt,pam_mut_annot,pam_mut_sgrna_id,mave_nt,mave_nt_ref,vcf_var_in_const",
-      "oligo1,homo sapiens,GRCh38,GENE1,AA1,ref,chr1,+,100,200,0,ATGC,ATGC,alias1,var1,120,A,T,K,N,1del,mut1,50,ATGC,ATGC,annot1,guide1,A,A,del1"
-      ),
-    file.path(tmp_dir, "#meta.csv")
-  )
-
-  writeLines(
-  c(
-    "##Command: pyquest",
-    "##Version: 1.1.0",
-    "#ID\tNAME\tSEQUENCE\tLENGTH\tCOUNT\tUNIQUE\tSAMPLE",
-    "1\ta\tATCG\t4\t5\t1\ts1",
-    "2\tb\tATGC\t4\t10\t1\ts1"
-    ),
-   file.path(tmp_dir, "lib#_counts.tsv")
-  )
-
-  writeLines(
-    c(
-      "##Command: pyquest",
-      "##Version: 1.1.0",
-      "#SEQUENCE\tLENGTH\tCOUNT",
-      "ATCG\t4\t5",
-      "ATGC\t4\t10"
-      ),
-     file.path(tmp_dir, "query_counts.tsv")
+    # Generate files that the samplesheet points to
+    writeLines(
+        c(
+            "oligo_name,ref_seq,pam_seq",
+            "oligo1,ATGC,ATGC"
+        ),
+        file.path(tmp_dir, "#meta.csv")
     )
 
-  writeLines(
-    c(
-        "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
-        "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences.tsv\tR1\tDay0\tDay0\tATCG\tATCG"
-    ),
-    file.path(tmp_dir, "samplesheet.tsv")
-  )
+    writeLines(
+        c(
+            "##Command: pyquest",
+            "##Version: 1.1.0",
+            "#ID\tNAME\tSEQUENCE\tLENGTH\tCOUNT\tUNIQUE\tSAMPLE",
+            "1\ta\tATCG\t4\t5\t1\ts1",
+            "2\tb\tATGC\t4\t10\t1\ts1"
+        ),
+        file.path(tmp_dir, "lib#_#counts.tsv")
+      )
 
-  # Run function
-  sge_objects <- import_sge_files(dir_path = tmp_dir, sample_sheet = "samplesheet.tsv")
+    writeLines(
+        c(
+            "##Command: pyquest",
+            "##Version: 1.1.0",
+            "#SEQUENCE\tLENGTH\tCOUNT",
+            "ATCG\t4\t5",
+            "ATGC\t4\t10"
+        ),
+        file.path(tmp_dir, "query_counts.tsv")
+      )
 
-  # Check filenames are preserved
-  df <- get("qc_samplesheet", envir = .GlobalEnv)
+    writeLines(
+        c(
+            "unique_oligo_name\tGene\tSYMBOL\tTargeton_ID\tsgRNA_id\tFeature\tEXON\tSeq",
+            "ENST01OLG1\tgene1\tg1\tAAAA\t001\tENST01\t-\tATCG"
+        ),
+        file.path(tmp_dir, "meta_consequences###.tsv")
+    )
 
-  expect_equal(df$fastq_1[1], "sample1#.fastq.gz")
-  expect_equal(df$valiant_meta[1], "#meta.csv")
-  expect_equal(df$library_dependent_count[1], "lib#_counts.tsv")
-  expect_equal(df$library_independent_count[1], "query_counts.tsv")
-  expect_equal(df$vep_anno[1], "meta_consequences.tsv")
+    # Generate samplesheet
+    writeLines(
+        c(
+            "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
+            "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_#counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences###.tsv\tR1\tDay0\tDay0\tATCG\tATCG"
+        ),
+        file.path(tmp_dir, "samplesheet.tsv")
+    )
+
+    # Run function and get samplesheet df object
+    sge_objects <- import_sge_files(dir_path = tmp_dir,
+                                    sample_sheet = "samplesheet.tsv")
+
+    samplesheet_df <- get("qc_samplesheet", envir = .GlobalEnv)
+
+    # Check filenames are preserved
+    expect_equal(samplesheet_df$fastq_1[1], "sample1#.fastq.gz")
+    expect_equal(samplesheet_df$valiant_meta[1], "#meta.csv")
+    expect_equal(samplesheet_df$library_dependent_count[1], "lib#_#counts.tsv")
+    expect_equal(samplesheet_df$library_independent_count[1], "query_counts.tsv")
+    expect_equal(samplesheet_df$vep_anno[1], "meta_consequences###.tsv")
 })

--- a/tests/testthat/test_qc_reports.R
+++ b/tests/testthat/test_qc_reports.R
@@ -1,0 +1,283 @@
+library(testthat)
+library(withr)
+
+test_that("HTML Plasmid QC report is generated", {
+    withr::local_tempdir()
+
+    # Create files tsv
+    samplesheet <- tempfile(pattern = "samplesheet", tmpdir = tempdir(), fileext = ".tsv")
+    writeLines(
+      c(
+        "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
+        "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_#counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences###.tsv\tR1\tDay0\tDay0\tATCG\tATCG"
+      ),
+      samplesheet
+    )
+
+    writeLines(
+        c(
+          "num_total_reads\tper_missing_variants\tseq_low_count\tseq_low_sample_per\tnum_accepted_reads\tper_mapping_reads\tper_ref_reads\tper_library_reads\tlibrary_cov\tlow_abundance_per\tlow_abundance_lib_per",
+          "100\t1\t1\t1\t100\t1\t1\t1\t1\t1\t1"
+        ),
+    file.path(tempdir(), "sample_qc_cutoffs.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\t% Library Reads\t% Reference Reads\t% PAM Reads\t% Unmapped Reads\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t50\t10\t10\t30\t40\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_accepted.tsv"))
+
+    writeLines(
+        c(
+          "sample_name\tsample_info\tgene_id\tgene_name\ttranscript_id\texon_num\ttargeton_id\tsgrna_id",
+          "AAAA\tAAAA_Day0_R1\tENST01\tgene1\tENST01\t-\tAAAA\t1"
+        ),
+    file.path(tempdir(), "sample_qc_meta.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tLibrary Sequences\tMissing Library Sequences\t% Missing Library Sequences\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t10\t1\t0.1\t1\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_missing.tsv"))
+
+    writeLines(
+        c(
+          "id\tname\tsequence\tlength\tcount\tunique\tsample\tis_ref\tis_pam",
+          "1\tENST01_chr1:1_100_clinvar\tATCG\t100\t0\t1\tsample\t0\t0"
+        ),
+    file.path(tempdir(), "missing_variants_in_library.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tAccepted Reads\t% Accepted Reads\tExcluded Reads\t% Excluded Reads\tTotal Reads\tPass Threshold\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t1\t75\t1\t25\t1\t1000000\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_total.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tTotal Library Reads\tTotal Library Sequences\tLibrary Coverage\tMedian Coverage\tPass Threshold\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t1\t500\t1000\t5000\t100\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_coverage.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tChromosome\tStrand\tGenomic Start\tGenomic End\t% Low Abundance\tLow Abundance cutoff\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\tchr1\t+\t100\t200\t0.1\t5\t30\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_pos_coverage.tsv"))
+
+    writeLines(
+        c(
+          "AAAA",
+          "1000",
+          "2000",
+          "3000"
+        ),
+    file.path(tempdir(), "sample_qc_stats_pos_counts.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tGini Coefficient\tTotal Reads\t% Missing Variants\tAccepted Reads\t% Mapping Reads\t% Reference Reads\t% Library Reads\tLibrary Coverage\t% R1 Adaptor\t% R2 Adaptor\tQCPass_Library_Per",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t0.2\tTRUE\tTRUE\tTRUE\t50\tTRUE\tTRUE\tTRUE\t95\t0\t55"
+        ),
+    file.path(tempdir(), "sample_qc_results.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tTotal Reads\t% 0 ~ 50\t% 50 ~ 100\t% 100 ~ 150\t% 150 ~ 200\t% 200 ~ 250\t% 250 ~ 300\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_Day0_R1\tENST01\t1000\t0\t0.1\t0.5\t0.5\t2.5\t95\t90\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_read_length.tsv"))
+
+    # Create files png
+    make_dummy_png <- function(name) {
+        png(file.path(tempdir(), name))
+        plot(1, 1)
+        dev.off()
+    }
+    
+    png_files <- c(
+        "sample_qc_read_length.png",
+        "sample_qc_stats_total.png",
+        "sample_qc_stats_accepted.png",
+        "sample_qc_position_cov.dots.png",
+        "sample_qc_position_cov.dots.png"
+    )
+    
+    lapply(png_files, make_dummy_png)
+
+    # Run function
+    create_qc_reports(
+        samplesheet = samplesheet,
+        qc_type = "plasmid",
+        qc_dir = tempdir()
+    )
+  
+    output_file <- file.path(tempdir(), "MAVEQC_report.html")
+  
+    # Check file exists and not empty
+    expect_true(file.exists(output_file))
+    expect_gt(file.info(output_file)$size, 0)
+})
+
+
+test_that("HTML Screen QC report is generated", {
+    withr::local_tempdir()
+
+    # Create files tsv
+    samplesheet <- tempfile(pattern = "samplesheet", tmpdir = tempdir(), fileext = ".tsv")
+    writeLines(
+      c(
+        "sample_name\tfastq_1\tlibrary_name\tlibrary_type\tvaliant_meta\tlibrary_dependent_count\tlibrary_independent_count\tper_r1_adaptor\tper_r2_adaptor\tvep_anno\treplicate\tref_time_point\tcondition\tadapt3\tadapt5",
+        "AAAA\tsample1#.fastq.gz\tAAAA\tplasmid\t#meta.csv\tlib#_#counts.tsv\tquery_counts.tsv\t95\t0\tmeta_consequences###.tsv\tR1\tHPLE_Day4_R1\tDay4\tATCG\tATCG"
+      ),
+      samplesheet
+    )
+
+    writeLines(
+        c(
+          "num_total_reads\tper_missing_variants\tseq_low_count\tseq_low_sample_per\tnum_accepted_reads\tper_mapping_reads\tper_ref_reads\tper_library_reads\tlibrary_cov\tlow_abundance_per\tlow_abundance_lib_per",
+          "100\t1\t1\t1\t100\t1\t1\t1\t1\t1\t1"
+        ),
+    file.path(tempdir(), "sample_qc_cutoffs.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\t% Library Reads\t% Reference Reads\t% PAM Reads\t% Unmapped Reads\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t50\t10\t10\t30\t40\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_accepted.tsv"))
+
+    writeLines(
+        c(
+          "sample_name\tsample_info\tgene_id\tgene_name\ttranscript_id\texon_num\ttargeton_id\tsgrna_id",
+          "AAAA\tAAAA_day4_R1\tENST01\tgene1\tENST01\t-\tAAAA\t1"
+        ),
+    file.path(tempdir(), "sample_qc_meta.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tLibrary Sequences\tMissing Library Sequences\t% Missing Library Sequences\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t10\t1\t0.1\t1\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_missing.tsv"))
+
+    writeLines(
+        c(
+          "id\tname\tsequence\tlength\tcount\tunique\tsample\tis_ref\tis_pam",
+          "1\tENST01_chr1:1_100_clinvar\tATCG\t100\t0\t1\tsample\t0\t0"
+        ),
+    file.path(tempdir(), "missing_variants_in_library.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tAccepted Reads\t% Accepted Reads\tExcluded Reads\t% Excluded Reads\tTotal Reads\tPass Threshold\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t1\t75\t1\t25\t1\t1000000\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_total.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tTotal Library Reads\tTotal Library Sequences\tLibrary Coverage\tMedian Coverage\tPass Threshold\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t1\t500\t1000\t5000\t100\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_coverage.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tChromosome\tStrand\tGenomic Start\tGenomic End\t% Low Abundance\tLow Abundance cutoff\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\tchr1\t+\t100\t200\t0.1\t5\t30\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_pos_coverage.tsv"))
+
+    writeLines(
+        c(
+          "AAAA",
+          "1000",
+          "2000",
+          "3000"
+        ),
+    file.path(tempdir(), "sample_qc_stats_pos_counts.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tGini Coefficient\tTotal Reads\t% Missing Variants\tAccepted Reads\t% Mapping Reads\t% Reference Reads\t% Library Reads\tLibrary Coverage\t% R1 Adaptor\t% R2 Adaptor\tQCPass_Library_Per",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t0.2\tTRUE\tTRUE\tTRUE\t50\tTRUE\tTRUE\tTRUE\t95\t0\t55"
+        ),
+    file.path(tempdir(), "sample_qc_results.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tTotal Reads\t% 0 ~ 50\t% 50 ~ 100\t% 100 ~ 150\t% 150 ~ 200\t% 200 ~ 250\t% 250 ~ 300\tPass Threshold (%)\tPass",
+          "TEST\tAAAA\tAAAA_day4_R1\tENST01\t1000\t0\t0.1\t0.5\t0.5\t2.5\t95\t90\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_read_length.tsv"))
+
+    writeLines(
+        c(
+          "Group\tSample\tSample Info\tSample Exon\tChromosome\tStrand\tGenomic Start\tGenomic End\t% Low Abundance (LOF)\t% Low Abundance (Others)\t% Low Abundance (ALL)\t% Low Abundance cutoff\tPass Threshold\tPass",
+          "TEST\tAAAA_A_4_pel001\tAAAA_Day4_R1\tENST01\tchr1\t+\t1\t1000\t1\t2\t3\t0.005\t30\tTRUE"
+        ),
+    file.path(tempdir(), "sample_qc_stats_pos_percentage.tsv"))
+  
+    writeLines(
+        c(
+          "Sample\tCluster\tReplicate\tCondition\tAAAA_A_4_pel001\tPass",
+          "AAAA_A_4_pel001\t1\tR1\tDay4\t0.95\tTRUE"
+        ),
+    file.path(tempdir(), "experiment_qc_corr.tsv"))
+
+    writeLines(
+        c(
+          "oligo_name\tconsequence\tposition\tlog2FoldChange\tlfcSE\tpadj\tstat\tsequence\tadj_log2FoldChange\tadj_score\tadj_pval\tadj_fdr",
+          "ENST01_chr1:1_100__CGC>TAC_aa\tMissense_Variant\t100\t-2.4601\t1\t1\tno impact\tATCG\t-2.4601\t-2.4601\t1\t1"
+        ),
+    file.path(tempdir(), "experiment_qc_deseq_fc.test.all.tsv"))
+
+    writeLines(
+        c(
+          "consequence\tnumber of depleted\tnumber of no impact\tnumber of enriched\tlfc range\ttotal number\ttotal number of outside range",
+           "Synonymous_Variant\t0\t155\t0\t-6 ~ 2\t155\t0"
+          ),
+    file.path(tempdir(), "experiment_qc_deseq_fc.test.all_sum.tsv"))
+
+    # Create files png
+    make_dummy_png <- function(name) {
+        png(file.path(tempdir(), name))
+        plot(1, 1)
+        dev.off()
+    }
+    
+    png_files <- c(
+        "sample_qc_read_length.png",
+        "sample_qc_stats_total.png",
+        "sample_qc_stats_accepted.png",
+        "sample_qc_position_cov.dots.png",
+        "sample_qc_position_cov.dots.png",
+        "sample_qc_position_anno.lof_dots.png",
+        "experiment_qc_samples_tree.png",
+        "experiment_qc_samples_corr.png",
+        "experiment_qc_pca_samples.png",
+        "experiment_qc_deseq_fc.test.all_beeswarm.png",
+        "experiment_qc_deseq_fc.test.all_position.png"
+    )
+    
+    lapply(png_files, make_dummy_png)
+
+    # Run function
+    create_qc_reports(
+        samplesheet = samplesheet,
+        qc_type = "screen",
+        qc_dir = tempdir()
+    )
+  
+    output_file <- file.path(tempdir(), "MAVEQC_report.html")
+  
+    # Check file exists and not empty
+    expect_true(file.exists(output_file))
+    expect_gt(file.info(output_file)$size, 0)
+})


### PR DESCRIPTION
Includes changes in version 0.2.10.229, which handles '#' in filenames when reading sample sheets by disabling comment parsing